### PR TITLE
Queue/fix Header focus outline/set masthead on router

### DIFF
--- a/src/client/components/Profile/ProfileCard.js
+++ b/src/client/components/Profile/ProfileCard.js
@@ -1,37 +1,32 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 const ProfileCard = () => {
   return (
     <div>
-      <Link to="/">
-        <div className="w-25 d-flex justify-content-around bg-dark align-items-center p-2">
+      <div className="d-flex justify-content-around bg-dark align-items-center p-2">
+        <div>
+          <img
+            src="https://mmart.de/wp-content/uploads/2017/09/Avatar-Icon-1.jpg"
+            alt="avatar"
+            width="60"
+            height="60"
+            className="rounded-circle mr-2"
+          />
+        </div>
+        <div className="text-light">
+          <p className="lead mb-2">Minh Anh Nguyen</p>
           <div>
-            <img
-              src="https://mmart.de/wp-content/uploads/2017/09/Avatar-Icon-1.jpg"
-              alt="avatar"
-              width="80"
-              height="80"
-              className="rounded-circle mr-2"
-            />
-          </div>
-          <div className="text-light">
-            <p className="lead mb-2">Minh Anh Nguyen</p>
-            <div>
-              <div className="d-flex justify-content-start">
-                <i className="fas fa-circle text-success mt-1 mr-2" />
-                <div className="font-weight-light font-italic">In Queue</div>
-              </div>
-              <div className="d-flex justify-content-start">
-                <i className="fas fa-circle text-danger mt-1 mr-2" />
-                <div className="font-weight-light font-italic">
-                  Not in Queue.
-                </div>
-              </div>
+            <div className="d-flex justify-content-start">
+              <i className="fas fa-circle text-success mt-1 mr-2" />
+              <div className="font-weight-light font-italic">In Queue</div>
+            </div>
+            <div className="d-none justify-content-start">
+              <i className="fas fa-circle text-danger mt-1 mr-2" />
+              <div className="font-weight-light font-italic">Not in Queue.</div>
             </div>
           </div>
         </div>
-      </Link>
+      </div>
     </div>
   );
 };

--- a/src/client/components/View/Queue.js
+++ b/src/client/components/View/Queue.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import QueueCard from './QueueCard';
+import './view.css';
+
+const Queue = () => {
+  return (
+    <div>
+      <div className="queue col-4 bg-dark p-3">
+        <div className="lead bg-success text-center py-4 text-light">
+          Q u e u e &nbsp;&nbsp; l i s t
+        </div>
+        <ul className="list-group">
+          <li className="list-group-item p-0 ml-2 border-top-0">
+            <QueueCard />
+          </li>
+          <li className="list-group-item p-0 ml-2">
+            <QueueCard />
+          </li>
+          <li className="list-group-item p-0 ml-2">
+            <QueueCard />
+          </li>
+          <li className="list-group-item p-0 ml-2">
+            <QueueCard />
+          </li>
+          <li className="list-group-item p-0 ml-2">
+            <QueueCard />
+          </li>
+          <li className="list-group-item p-0 ml-2">
+            <QueueCard />
+          </li>
+          <li className="list-group-item p-0 ml-2 border-0">
+            <QueueCard />
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default Queue;

--- a/src/client/components/View/QueueCard.js
+++ b/src/client/components/View/QueueCard.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import ProfileCard from '../Profile/ProfileCard';
+
+const QueueCard = () => {
+  return (
+    <div>
+      <div className="row">
+        <div className="col-10 p-0">
+          <ProfileCard />
+        </div>
+        <div className="col-2 p-0 bg-dark">
+          <button
+            className="btn h-50 btn-danger rounded-0 mt-3 ml-2 px-3"
+            type="button"
+          >
+            <i className="fas fa-times" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QueueCard;

--- a/src/client/components/View/view.css
+++ b/src/client/components/View/view.css
@@ -1,0 +1,10 @@
+.list-group {
+  max-height: 200px;
+  overflow: hidden;
+  overflow-y: scroll;
+  padding-right: 17px;
+  box-sizing: content-box;
+}
+.queue {
+  overflow: hidden;
+}

--- a/src/client/routing/Routes.js
+++ b/src/client/routing/Routes.js
@@ -7,15 +7,17 @@ import Alert from '../layout/Alert';
 import PrivateRoute from './PrivateRoute';
 import NotFound from '../layout/NotFound';
 import Faq from '../components/Faq';
+import Queue from '../components/View/Queue';
 
 const Routes = () => {
   return (
-    <section className="container">
+    <section className="masthead">
       <Alert />
       <Switch>
         <Route exact path="/register" component={Register} />
         <Route exact path="/faq" component={Faq} />
         <Route exact path="/login" component={Login} />
+        <Route exact path="/queue" component={Queue} />
         <PrivateRoute exact path="/test" component={Test} />
         <Route component={NotFound} />
       </Switch>

--- a/src/client/style.css
+++ b/src/client/style.css
@@ -7,6 +7,9 @@
   --success-color: #28a745;
 }
 
+a:focus {
+  outline: none;
+}
 /* COLOR */
 .bg-pale-green {
   background-color: rgba(50, 58, 20, 0.7) !important;
@@ -16,7 +19,6 @@
 }
 
 .masthead {
-  height: 100vh;
   min-height: 500px;
   background: linear-gradient(
       to bottom,
@@ -40,6 +42,9 @@
 }
 .navbar .navbar-nav .btn {
   padding: 0.5rem 0.75rem !important;
+}
+.navbar .navbar-nav .btn:focus {
+  box-shadow: none !important;
 }
 /* FOOTER CSS */
 .about {


### PR DESCRIPTION
- raw Queue design:
      + QueueCard from ProfileCard
- create folder View for student and tutor view (profile is not yet added to view)
      + add view.css for later view design
- fix Header focus outline
- set "container" to "masthead" in Routes.js/create a public route to queue
      + change masthead bg to min-height 500px